### PR TITLE
fix: Switch to hatch build and tag-based publishing to resolve PyPI l…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,37 +1,83 @@
-name: Publish to PyPI
+name: Build and Publish to PyPI
 
 on:
-  release:
-    types: [published]
-  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'  # Trigger on version tags (v1.0.0, v0.8.1, etc.)
+  workflow_dispatch:  # Allow manual triggering
 
 jobs:
-  build:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: uv sync --group dev
+
+      - name: Run tests
+        run: uv run pytest tests/
+
+  build-and-publish:
+    needs: test
     runs-on: ubuntu-latest
     permissions:
-      id-token: write # Add this to allow OIDC token fetching
-      contents: read # Explicitly limit repository contents access
+      id-token: write
+      contents: read
 
     steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required for hatch-vcs versioning
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.10"
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
 
-    - name: Install uv
-      uses: astral-sh/setup-uv@v4
-      with:
-        version: "latest"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
 
-    - name: Install dependencies
-      run: uv sync --group dev
+      - name: Install hatch
+        run: uv tool install hatch
 
-    - name: Build package
-      run: uv build
+      - name: Build package with hatch
+        run: uv tool run hatch build
 
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.12.4
+      - name: Check package
+        run: |
+          uv tool install twine
+          uv tool run twine check dist/*
+
+      - name: Verify version matches tag
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          PACKAGE_VERSION=$(uv tool run hatch version)
+          echo "Tag version: $TAG_VERSION"
+          echo "Package version: $PACKAGE_VERSION"
+          if [ "$TAG_VERSION" != "$PACKAGE_VERSION" ]; then
+            echo "Version mismatch! Tag: $TAG_VERSION, Package: $PACKAGE_VERSION"
+            exit 1
+          fi
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+        with:
+          verify-metadata: true
+          verbose: true


### PR DESCRIPTION
…ocal version error

- Replace uv build with hatch build to avoid local version generation
- Change trigger from release events to version tags (v*)
- Add test job that runs before publishing
- Add version verification to ensure tag matches package version
- Keep trusted publishing with OIDC tokens
- Follow pattern used by sibling projects

🤖 Generated with [Claude Code](https://claude.ai/code)