### PR TITLE
fix: Change PyPI package name to weather-context-mcp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
-name = "weather-mcp"
+name = "weather-context-mcp"
 dynamic = ["version"]
 description = "An MCP for retrieving historical weather data for a given location"
 readme = "README.md"


### PR DESCRIPTION
- Update package name to match trusted publishing setup
- Keep all code structure as weather_mcp (common pattern)
- Resolves 403 OIDC token validation error

🤖 Generated with [Claude Code](https://claude.ai/code)